### PR TITLE
bsd/ntp: Add stop and running control to ntpd

### DIFF
--- a/bsd/freebsd/contrib/ntp/libntp/msyslog.c
+++ b/bsd/freebsd/contrib/ntp/libntp/msyslog.c
@@ -157,7 +157,9 @@ addto_syslog(
 	int		pid;
 	const char *	nl_or_empty;
 	const char *	human_time;
-
+#ifdef __rtems__
+	extern int rtems_ntpd_log_to_term;
+#endif /* __rtems__ */
 	/* setup program basename static var prog if needed */
 	if (progname != prevcall_progname) {
 		prevcall_progname = progname;
@@ -178,6 +180,9 @@ addto_syslog(
 		if (syslog_file != NULL)
 			log_to_file = TRUE;
 		else
+#ifdef __rtems__
+			if (rtems_ntpd_log_to_term)
+#endif /* __rtems__ */
 			log_to_term = TRUE;
 #if DEBUG
 	if (debug > 0)
@@ -419,6 +424,7 @@ init_logging(
 		*cp = '\0';
 #endif
 
+#ifndef __rtems__
 #if !defined(VMS)
 
 	if (is_daemon)
@@ -441,6 +447,7 @@ init_logging(
 		setlogmask(LOG_UPTO(LOG_DEBUG)); /* @@@ was INFO */
 # endif /* LOG_DAEMON */
 #endif	/* !VMS */
+#endif /* __rtems__ */
 }
 
 

--- a/bsd/rtemsbsd/include/rtems/ntpd.h
+++ b/bsd/rtemsbsd/include/rtems/ntpd.h
@@ -50,10 +50,31 @@ extern "C" {
  *
  * @param argv is the vector of arguments.
  *
- * @return This function should never return.  If it returns, then there is a
+ * @return This function only returns if @ref rtems_ntpd_stop is
+ *   called or the daemon is already running  Any other reason is a
  *   serious error.
  */
 int rtems_ntpd_run(int argc, char **argv);
+
+/**
+ * @brief Stops the NTP daemon (nptd).
+ *
+ * The ntpd loop will exit when it next runs cleaning up. Use the
+ * @ref rtems_ntpd_running call to check if the daemon has stopped
+ * running.
+ *
+ * @return This function should never return.  If it returns, then there is a
+ *   serious error.
+ */
+void rtems_ntpd_stop(void);
+
+/**
+ * @brief Checks if the NTP daemon (nptd) is running?
+ *
+ * @return Return 1 if ntpd is running else 0 is returned.
+ */
+int rtems_ntpd_running(void);
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add functions to stop and check if ntpd is running.

Disable syslog and openlog output because they are not needed in RTEMS. This can be extended to allow syslog or to term if needed later.