### PR TITLE
Variable clean when stopping ntpd

### DIFF
--- a/bsd/freebsd/contrib/ntp/libntp/emalloc.c
+++ b/bsd/freebsd/contrib/ntp/libntp/emalloc.c
@@ -10,6 +10,16 @@
 #include "ntp_stdlib.h"
 
 
+#ifdef __rtems__
+#ifdef EREALLOC_IMPL
+static void *rtems_ntp_realloc(void *ptr, size_t size, const char* file, int line) {
+	void* mem = realloc(ptr, size);
+	printf("[EREMALLOC] %s:%d: ptr=%p mem=%p..%p newsz=%zu\n",
+		   file, line, ptr, mem, mem + size, size);
+	return mem;
+}
+#endif /* EREALLOC_IMPL */
+#endif /* __rtems__ */
 /*
  * When using the debug MS CRT allocator, each allocation stores the
  * callsite __FILE__ and __LINE__, which is then displayed at process

--- a/bsd/freebsd/contrib/ntp/ntpd/ntp_config.c
+++ b/bsd/freebsd/contrib/ntp/ntpd/ntp_config.c
@@ -223,6 +223,9 @@ int *p_bcXXXX_enabled = &bc_list[0].enabled;
 
 /* FUNCTION PROTOTYPES */
 
+#ifdef __rtems__
+#define FREE_CFG_T
+#endif /* __rtems__ */
 static void init_syntax_tree(config_tree *);
 static void apply_enable_disable(attr_val_fifo *q, int enable);
 
@@ -375,6 +378,25 @@ static int getnetnum(const char *num, sockaddr_u *addr, int complain,
 
 #endif
 
+#ifdef __rtems__
+#define RTEMS_NTP_CLEAR(_var) memset(&_var, 0, sizeof(_var))
+void rtems_ntp_config_globals_fini(void);
+void rtems_ntp_config_globals_fini(void) {
+	free_all_config_trees();
+	cur_memlock = -1;
+	RTEMS_NTP_CLEAR(cfgt);
+	cfg_tree_history = NULL;
+	RTEMS_NTP_CLEAR(sys_phone);
+	strlcpy(default_keysdir, NTP_KEYSDIR, sizeof(default_keysdir));
+	saveconfigdir = NULL;
+	config_priority_override = 0;
+	strlcpy(default_ntp_signd_socket, NTP_SIGND_PATH, sizeof(default_ntp_signd_socket));
+	RTEMS_NTP_CLEAR(remote_config);
+	old_config_style = 1;
+	cryptosw = 0;
+	stats_drift_file = NULL;
+}
+#endif /* __rtems__ */
 #if defined(__GNUC__) /* this covers CLANG, too */
 static void  __attribute__((noreturn,format(printf,1,2))) fatal_error(const char *fmt, ...)
 #elif defined(_MSC_VER)

--- a/bsd/freebsd/contrib/ntp/ntpd/ntp_control.c
+++ b/bsd/freebsd/contrib/ntp/ntpd/ntp_control.c
@@ -822,6 +822,63 @@ static	char *reqend;
 #define MIN(a, b) (((a) <= (b)) ? (a) : (b))
 #endif
 
+#ifdef __rtems__
+#define RTEMS_NTP_CLEAR(_var) memset(&_var, 0, sizeof(_var))
+void rtems_ntp_control_globals_fini(void);
+void rtems_ntp_control_globals_fini(void) {
+	if (ext_sys_var != NULL) {
+		const u_short cv = count_var(ext_sys_var);
+		struct ctl_var *k;
+		u_short c;
+		k = ext_sys_var;
+		for (c = 0; c < cv; ++c) {
+			if (k[c].text != NULL) {
+			  free((void*) k[c].text);
+			}
+		}
+		free(ext_sys_var);
+		ext_sys_var = NULL;
+	}
+	RTEMS_NTP_CLEAR(ctl_traps);
+	num_ctl_traps = 0;
+	RTEMS_NTP_CLEAR(ctl_auth_keyid);
+	ctl_sys_last_event = 0;
+	ctl_sys_num_events = 0;
+	ctltimereset = 0U;
+	numctlreq = 0U;
+	numctlbadpkts = 0U;
+	numctlresponses = 0U;
+	numctlfrags = 0U;
+	numctlerrors = 0U;
+	numctltooshort = 0U;
+	numctlinputresp = 0U;
+	numctlinputfrag = 0U;
+	numctlinputerr = 0U;
+	numctlbadoffset = 0U;
+	numctlbadversion = 0U;
+	numctldatatooshort = 0U;
+	numctlbadop = 0U;
+	numasyncmsgs = 0U;
+	RTEMS_NTP_CLEAR(rpkt);
+	res_version = 0U;
+	res_opcode = 0U;
+	res_associd = 0U;
+	res_frags = 0U;
+	res_offset = 0U;
+	datapt = NULL;
+	dataend = NULL;
+	datalinelen = 0;
+	datasent = 0;
+	datalinelen = 0;
+	datanotbinflag = 0;
+	lcl_inter = NULL;
+	res_authenticate = 0U;
+	res_authokay = 0U;
+	res_keyid = 0U;
+	reqpt = NULL;
+	reqend = NULL;
+}
+#endif /* __rtems__ */
 /*
  * init_control - initialize request data
  */

--- a/bsd/freebsd/contrib/ntp/ntpd/ntp_crypto.c
+++ b/bsd/freebsd/contrib/ntp/ntpd/ntp_crypto.c
@@ -4171,4 +4171,8 @@ exten_payload_size(
 }
 # else	/* !AUTOKEY follows */
 int ntp_crypto_bs_pubkey;
+void rtems_ntp_crypto_globals_ini(void);
+void rtems_ntp_crypto_globals_ini(void) {
+	ntp_crypto_bs_pubkey = 0;
+}
 # endif	/* !AUTOKEY */

--- a/bsd/freebsd/contrib/ntp/ntpd/ntp_loopfilter.c
+++ b/bsd/freebsd/contrib/ntp/ntpd/ntp_loopfilter.c
@@ -193,6 +193,60 @@ static sigjmp_buf env;		/* environment var. for pll_trap() */
 #endif /* SIGSYS */
 #endif /* KERNEL_PLL */
 
+#ifdef __rtems__
+#define RTEMS_NTP_CLEAR(_var) memset(&_var, 0, sizeof(_var))
+void rtems_ntp_loopfilter_globals_fini(void);
+void rtems_ntp_loopfilter_globals_fini(void) {
+	clock_max_back = CLOCK_MAX;
+	clock_max_fwd =  CLOCK_MAX;
+	clock_minstep = CLOCK_MINSTEP;
+	clock_panic = CLOCK_PANIC;
+	clock_phi = CLOCK_PHI;
+	allan_xpt = CLOCK_ALLAN;
+	clock_offset = 0;
+	clock_jitter = 0;
+	drift_comp = 0;
+	init_drift_comp = 0;
+	clock_stability = 0;
+	clock_codec = 0;
+	clock_epoch = 0;
+	sys_tai = 0;
+	loop_started = 0;
+	RTEMS_NTP_CLEAR(relative_path);
+	this_file = NULL;
+	ntp_enable = TRUE;
+	pll_control = 0;
+	kern_enable = TRUE;
+	hardpps_enable;
+	ext_enable = 0;
+	pps_stratum = 0;
+	kernel_status = 0;
+	force_step_once = FALSE;
+	mode_ntpdate = FALSE;
+	freq_cnt = 0;
+	freq_set = 0;
+	state = 0;
+	sys_poll = 0;
+	tc_counter = 0;
+	last_offset = 0.0;
+
+/*
+ * Clock state machine variables
+ */
+int	state = 0;		/* clock discipline state */
+u_char	sys_poll;		/* time constant/poll (log2 s) */
+int	tc_counter;		/* jiggle counter */
+double	last_offset;		/* last offset (s) */
+
+/*
+ * Huff-n'-puff filter variables
+ */
+static double *sys_huffpuff;	/* huff-n'-puff filter */
+static int sys_hufflen;		/* huff-n'-puff filter stages */
+static int sys_huffptr;		/* huff-n'-puff filter pointer */
+static double sys_mindly;	/* huff-n'-puff filter min delay */
+}
+#endif /* __rtems__ */
 static void
 sync_status(const char *what, int ostatus, int nstatus)
 {

--- a/bsd/freebsd/contrib/ntp/ntpd/ntp_monitor.c
+++ b/bsd/freebsd/contrib/ntp/ntpd/ntp_monitor.c
@@ -98,6 +98,20 @@ u_char	ntp_minpoll = NTP_MINPOLL;	/* increment (log 2 s) */
 			MRU_MAXDEPTH_DEF;
 	int	mon_age = 3000;		/* preemption limit */
 
+#ifdef __rtems__
+#define RTEMS_NTP_CLEAR(_var) memset(&_var, 0, sizeof(_var))
+void rtems_ntp_monitor_globals_fini(void);
+void rtems_ntp_monitor_globals_fini(void) {
+	mon_stop(MON_ON | MON_RES);
+	ntp_minpkt = NTP_MINPKT;
+	ntp_minpoll = NTP_MINPOLL;
+	mon_enabled = 0;
+	mru_mindepth = 600;
+	mru_maxage = 64;
+	mru_maxdepth = MRU_MAXDEPTH_DEF;
+	mon_age = 3000;
+}
+#endif /* __rtems__ */
 static	void		mon_getmoremem(void);
 static	void		remove_from_hash(mon_entry *);
 static	inline void	mon_free_entry(mon_entry *);
@@ -498,5 +512,3 @@ ntp_monitor(
 
 	return mon->flags;
 }
-
-

--- a/bsd/freebsd/contrib/ntp/ntpd/ntp_peer.c
+++ b/bsd/freebsd/contrib/ntp/ntpd/ntp_peer.c
@@ -125,6 +125,28 @@ static void		getmorepeermem(void);
 static int		score(struct peer *);
 
 
+#ifdef __rtems__
+#define RTEMS_NTP_CLEAR(_var) memset(&_var, 0, sizeof(_var))
+void rtems_ntp_peer_globals_fini(void);
+void rtems_ntp_peer_globals_fini(void) {
+	/* we cannot clean up the peers list because eallocarray keeps
+	 * no base to free; move to free */
+	while (peer_list != NULL) {
+		unpeer(peer_list);
+	}
+	current_association_ID = 0;
+	initial_association_ID = 0;
+	peer_timereset = 0;
+	findpeer_calls = 0;
+	assocpeer_calls = 0;
+	peer_allocations = 0;
+	peer_demobilizations = 0;
+	total_peer_structs = 0;
+	total_peer_structs = 0;
+	peer_associations = 0;
+	peer_preempt = 0;
+}
+#endif /* __rtems__ */
 /*
  * init_peer - initialize peer data structures and counters
  *

--- a/bsd/freebsd/contrib/ntp/ntpd/ntp_proto.c
+++ b/bsd/freebsd/contrib/ntp/ntpd/ntp_proto.c
@@ -213,6 +213,80 @@ void	pool_name_resolved	(int, int, void *, const char *,
 const char *	amtoa		(int am);
 
 
+#ifdef __rtems__
+#define RTEMS_NTP_CLEAR(_var) memset(&_var, 0, sizeof(_var))
+static struct endpoint *endpoint = NULL;
+static int *indx = NULL;
+static peer_select *peers = NULL;
+static u_int endpoint_size = 0;
+static u_int peers_size = 0;
+static u_int indx_size = 0;
+void rtems_ntp_proto_globals_fini(void);
+void rtems_ntp_proto_globals_fini(void) {
+	sys_leap = 0;
+	xmt_leap = 0;
+	sys_stratum = 0;
+	sys_precision = 0;
+	sys_rootdelay = 0;
+	sys_rootdelay = 0.0;
+	sys_rootdisp = 0.0;
+	sys_refid = 0;
+	RTEMS_NTP_CLEAR(sys_reftime);
+	sys_peer = NULL;
+	sys_bclient = 0;
+	sys_bdelay = 0.0;
+	sys_authenticate = 0;
+	RTEMS_NTP_CLEAR(sys_authdelay);
+	sys_offset = 0.0;
+	sys_mindisp = MINDISPERSE;
+	sys_maxdist = MAXDISTANCE;
+	sys_jitter = 0.0;
+	sys_epoch = 0U;
+	sys_clockhop = 0.0;
+	leap_vote_ins = 0;
+	leap_vote_del = 0;
+	sys_private = 0;
+	sys_manycastserver = 0;
+	ntp_mode7 = 0;
+	peer_ntpdate = 0;
+	sys_survivors = 0;
+	sys_ident = NULL;
+	sys_floor = 0;
+	sys_bcpollbstep = 0;
+	sys_ceiling = STRATUM_UNSPEC - 1;
+	sys_minsane = 1;
+	sys_minclock = NTP_MINCLOCK;
+	sys_maxclock = NTP_MAXCLOCK;
+	sys_cohort = 0;
+	sys_orphan = STRATUM_UNSPEC + 1;
+	sys_orphwait = NTP_ORPHWAIT;
+	sys_beacon = BEACON;
+	sys_ttlmax = 0;
+	memset(sys_ttl, 0, sizeof(sys_ttl));
+	sys_stattime = 0U;
+	sys_received = 0U;
+	sys_processed = 0U;
+	sys_newversion = 0U;
+	sys_oldversion = 0U;
+	sys_restricted = 0U;
+	sys_badlength = 0U;
+	sys_badauth = 0U;
+	sys_declined = 0U;
+	sys_limitrejected = 0U;
+	sys_kodsent = 0U;
+	peer_clear_digest_early	= 1;
+	unpeer_crypto_early = 1;
+	unpeer_crypto_nak_early	= 1;
+	unpeer_digest_early	= 1;
+	dynamic_interleave = DYNAMIC_INTERLEAVE;
+	free(endpoint);
+	endpoint = NULL;
+	indx = NULL;
+	endpoint_size = 0;
+	peers_size = 0;
+	indx_size = 0;
+}
+#endif /* __rtems__ */
 void
 set_sys_leap(
 	u_char new_sys_leap
@@ -3351,12 +3425,14 @@ clock_select(void)
 	struct peer *typelocal = NULL;
 	struct peer *typepps = NULL;
 #endif /* REFCLOCK */
+#ifndef __rtems__
 	static struct endpoint *endpoint = NULL;
 	static int *indx = NULL;
 	static peer_select *peers = NULL;
 	static u_int endpoint_size = 0;
 	static u_int peers_size = 0;
 	static u_int indx_size = 0;
+#endif /* __rtems__ */
 	size_t octets;
 
 	/*

--- a/bsd/freebsd/contrib/ntp/ntpd/ntp_request.c
+++ b/bsd/freebsd/contrib/ntp/ntpd/ntp_request.c
@@ -227,6 +227,27 @@ static int usingexbuf;
 static sockaddr_u *toaddr;
 static endpt *frominter;
 
+#ifdef __rtems__
+#define RTEMS_NTP_CLEAR(_var) memset(&_var, 0, sizeof(_var))
+void rtems_ntp_request_globals_fini(void);
+void rtems_ntp_request_globals_fini(void) {
+	info_auth_keyid = 0;
+	numrequests = 0U;
+	numresppkts = 0U;
+	RTEMS_NTP_CLEAR(errorcounter);
+	auth_timereset = 0U;
+	RTEMS_NTP_CLEAR(rpkt);
+	reqver = 0;
+	seqno = 0;
+	nitems = 0;
+	itemsize = 0;
+	databytes = 0;
+	RTEMS_NTP_CLEAR(exbuf);
+	usingexbuf = 0;
+	toaddr = NULL;
+	frominter = NULL;
+}
+#endif /* __rtems__ */
 /*
  * init_request - initialize request data
  */
@@ -2786,4 +2807,3 @@ do_if_reload(
 	
 	flush_pkt();
 }
-

--- a/bsd/freebsd/contrib/ntp/ntpd/ntp_restrict.c
+++ b/bsd/freebsd/contrib/ntp/ntpd/ntp_restrict.c
@@ -121,6 +121,40 @@ static char *		roptoa(restrict_op op);
 
 void	dump_restricts(void);
 
+#ifdef __rtems__
+#define RTEMS_NTP_CLEAR(_var) memset(&_var, 0, sizeof(_var))
+void rtems_ntp_restrict_globals_fini(void);
+void rtems_ntp_restrict_globals_fini(void) {
+	restrict_u* res;
+	restrict_u* next;
+	for (res = restrictlist4; res != NULL; res = next) {
+		next = res->link;
+		if (res != &restrict_def4) {
+			free_res(res, 0);
+		}
+	}
+	for (res = restrictlist6; res != NULL; res = next) {
+		next = res->link;
+		if (res != &restrict_def6) {
+			free_res(res, 1);
+		}
+	}
+	restrictlist4 = NULL;
+	restrictlist6 = NULL;
+	restrictcount = 0;
+	/* resfree4 and resfree6 hold free structs to use, leave them */
+	res_calls = 0;
+	res_found = 0;
+	res_not_found = 0;
+	res_limited_refcnt = 0;
+	RTEMS_NTP_CLEAR(restrict_def4);
+	RTEMS_NTP_CLEAR(restrict_def6);
+	restrict_source_enabled = 0;
+	restrict_source_rflags = 0;
+	restrict_source_mflags = 0;
+	restrict_source_ippeerlimit = 0;
+}
+#endif /* __rtems__ */
 /*
  * dump_restrict - spit out a restrict_u
  */

--- a/bsd/freebsd/contrib/ntp/ntpd/ntp_timer.c
+++ b/bsd/freebsd/contrib/ntp/ntpd/ntp_timer.c
@@ -132,6 +132,28 @@ void	set_timer_or_die(const intervaltimer *);
 #endif
 
 
+#ifdef __rtems__
+void rtems_ntp_timer_globals_fini(void);
+void rtems_ntp_timer_globals_fini(void) {
+	interface_interval = 0;
+	initializing = 0;
+	alarm_flag = 0;
+	interface_timer = 0U;
+	adjust_timer = 0U;
+	stats_timer = 0U;
+	leapf_timer = 0U;
+	huffpuff_timer = 0U;
+	worker_idle_timer = 0U;
+	leapsec = 0U;
+	leapdif = 0;
+	orphwait = 0U;
+	alarm_overflow = 0U;
+	current_time = 0U;
+	timer_timereset = 0U;
+	timer_overflows = 9U;
+	timer_xmtcalls = 0U;
+}
+#endif /* __rtems__ */
 #if !defined(SYS_WINNT) && !defined(VMS)
 void
 set_timer_or_die(

--- a/netservices.py
+++ b/netservices.py
@@ -250,7 +250,7 @@ def build(bld):
               use=[net_use])
     bld.install_files("${PREFIX}/" + arch_lib_path, ["libttcp.a"])
 
-    libs = ['rtemstest']
+    libs = ['rtemstest', 'debugger']
 
     ntp_test_incl = ntp_incl + ['testsuites']
     ntp_test_sources = ['testsuites/ntp01/test_main.c', net_adapter_source]


### PR DESCRIPTION
These patches destruct `ntpd` variables when `rtems_ntpd_stop()` is called. The `ntpd` code does not clean up and assumes the process is killed and restarted. This change performs a reasonable clean up task. It is not 100% complete but all files in `ntp/ntpd` have been checked. There could be `static` variables in functions that have been missed. Only limited configurations have been tested.

Some memory cannot be freed back to the heap because the allocated address is not held for us in a `free` call. The allocated memory is broken up in chucks and placed on a list. In those cases the data is clean, closed or whatever and the memory is on a free list and can be used again.

The change:

1. Cleans up the workers waiting for them to finish. Memory is released
2. Frees all peers but does not free the memory due to not base addresses to free
3. Sets all global variables to the default state

I added debugger support into the `ntpd` test.