### PR TITLE
Fixes for ntpd and the unit test

### DIFF
--- a/bsd/freebsd/contrib/ntp/ntpd/ntp_io.c
+++ b/bsd/freebsd/contrib/ntp/ntpd/ntp_io.c
@@ -444,13 +444,18 @@ maintain_activefds(
 		FD_CLR(fd, &activefds);
 		if (maxactivefd && fd == maxactivefd) {
 #ifdef __rtems__
-			maxactivefd = 0;
+			int curr_maxactivefd = maxactivefd;
 #endif /* __rtems__ */
 			for (i = maxactivefd - 1; i >= 0; i--)
 				if (FD_ISSET(i, &activefds)) {
 					maxactivefd = i;
 					break;
 				}
+#ifdef __rtems__
+			if (curr_maxactivefd == maxactivefd) {
+				maxactivefd = 0;
+			}
+#endif /* __rtems__ */
 			INSIST(fd != maxactivefd);
 		}
 	}

--- a/bsd/freebsd/contrib/ntp/ntpd/ntpd.c
+++ b/bsd/freebsd/contrib/ntp/ntpd/ntpd.c
@@ -1594,8 +1594,8 @@ static void
 rtems_ntpd_cleanup(void) {
 	rtems_ntp_peer_globals_fini();
 	rtems_ntp_control_globals_fini();
-	rtems_ntp_worker_globals_fini();
 	rtems_ntp_intres_globals_fini();
+	rtems_ntp_worker_globals_fini();
 	rtems_ntp_proto_globals_fini();
 	rtems_ntp_io_globals_fini();
 	rtems_ntp_request_globals_fini();
@@ -1638,7 +1638,6 @@ rtems_ntpd_run(int argc, char **argv)
 	rtems_mutex_unlock(&ntpd_lock);
 	r = rtems_bsd_program_call_main("ntpd", ntpdmain, argc, argv);
 	rtems_mutex_lock(&ntpd_lock);
-	rtems_ntpd_cleanup();
 	ntpd_running = false;
 	rtems_mutex_unlock(&ntpd_lock);
 	return r;

--- a/netservices.py
+++ b/netservices.py
@@ -182,6 +182,11 @@ def bsp_configure(conf, arch_bsp):
     if stack_count != 1:
         conf.fatal('More than one networking stack found')
 
+    conf.check_cc(lib='debugger',
+                  ldflags=['-lrtemsdefaultconfig'],
+                  uselib_store='DEBUGGER',
+                  mandatory=False)
+
     net_check_libbsd(conf)
     net_check_legacy(conf)
     net_check_lwip(conf)
@@ -250,7 +255,9 @@ def build(bld):
               use=[net_use])
     bld.install_files("${PREFIX}/" + arch_lib_path, ["libttcp.a"])
 
-    libs = ['rtemstest', 'debugger']
+    libs = ['rtemstest']
+    if 'LIB_DEBUGGER' in bld.env:
+        libs += bld.env.LIB_DEBUGGER
 
     ntp_test_incl = ntp_incl + ['testsuites']
     ntp_test_sources = ['testsuites/ntp01/test_main.c', net_adapter_source]

--- a/testsuites/ntp01/test_main.c
+++ b/testsuites/ntp01/test_main.c
@@ -452,6 +452,8 @@ static rtems_task ntpd_runner(
       break;
     }
   }
+  printf("error: ntpd: task loop exiting");
+  rtems_task_delete(RTEMS_SELF);
 }
 
 static void run_test(void)
@@ -475,7 +477,7 @@ static void run_test(void)
   debugger_start();
   debugger_break();
 
-  sc = rtems_shell_init("SHLL", 16 * 1024, 1, CONSOLE_DEVICE_NAME,
+  sc = rtems_shell_init("SHLL", 32 * 1024, 1, CONSOLE_DEVICE_NAME,
     false, false, NULL);
   directive_failed( sc, "rtems_shell_init" );
   assert(sc == RTEMS_SUCCESSFUL);
@@ -586,5 +588,7 @@ static rtems_task Init( rtems_task_argument argument )
 
 #define CONFIGURE_UNLIMITED_OBJECTS
 #define CONFIGURE_UNIFIED_WORK_AREAS
+
+#define CONFIGURE_STACK_CHECKER_ENABLED
 
 #include <rtems/confdefs.h>


### PR DESCRIPTION
- The `ntpq` command uses around 17K of stack with `libbsd`. Increase the stack size of the shell to 32K
- A bug fix to handle removing the last fd from the activefd set if it is the max fd had a bug where the max active fd was incorrectly being set to `0` if the max fd is removed
- Only call the clean in the finish safe handle so an calls to exit or any asserts are correctly caught
- Set the `ntpq` fd set size
- Detect if the target supports `libdebugger`